### PR TITLE
else|break|next|repeat|in as Name.Function instead of Name

### DIFF
--- a/pygments/lexers/r.py
+++ b/pygments/lexers/r.py
@@ -89,7 +89,7 @@ class SLexer(RegexLexer):
             (r'\[{1,2}|\]{1,2}|\(|\)|;|,', Punctuation),
         ],
         'keywords': [
-            (r'(if|else|for|while|repeat|in|next|break|return|switch|function)'
+            (r'(if|for|while|return|switch|function)'
              r'(?![\w.])',
              Keyword.Reserved),
         ],
@@ -126,6 +126,7 @@ class SLexer(RegexLexer):
         ],
         'root': [
             # calls:
+            (r'\b(else|next|break|repeat|in)\b', Name.Function),
             (r'(%s)\s*(?=\()' % valid_name, Name.Function),
             include('statements'),
             # blocks:


### PR DESCRIPTION
# a R simple program; in R, "break", "else", "repeat"... are functions: break(), else(), repeat( {...} )
# 'break', 'next', 'else', 'repeat', 'in' are produced as "Name" tokens (although they are declared "Keyword.Reserved")
# we declare they as "Name.Function" (at start of tokens["root"], in SLexer class)

for(i in 1:10) { 
    if(i < 3) next  # instead of "next()", originally claimed by "Kewword.Function"
    print(i)
    if(i >= 5) break  # as per usual, instead of "break()" 
}